### PR TITLE
Use CRC32 for hashing seed string

### DIFF
--- a/diversitymod.py
+++ b/diversitymod.py
@@ -3,6 +3,7 @@ from Tkinter import *
 from tkFileDialog import askopenfilename
 from random import seed, sample, randint
 from PIL import Image, ImageFont, ImageDraw, ImageTk
+from binascii import crc32
 
 ##
 ## Get Steam path (verbatim lines from http://pastebin.com/z89Gr9NM)
@@ -46,7 +47,7 @@ def installDiversityMod():
 	# set the RNG seed
 	global dmseed
 	dmseed = entryseed.get()
-	seed(dmseed)
+	seed(crc32(dmseed))
 	
 	# set background to indicate that current entry is active
 	sentry.configure(bg = '#d8fbf8')


### PR DESCRIPTION
This change hashes the user submitted seed value with CRC32.

The reason for this is that calling seed(n), with n being a string and not a numeric value, forces Python to hash the string with the built-in hash() function which creates different results on different operating systems and maybe even different Python versions.

Using a specific yet simple algorithm like CRC32 guarantees that players on Mac OSX, Linux and Windows always get the same three starting items which at the moment is not the case (tested on Linux vs. Windows).
